### PR TITLE
handle internal analytics track request events

### DIFF
--- a/AEPAnalytics.xcodeproj/project.pbxproj
+++ b/AEPAnalytics.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		D6D5F35F25C88070008148B3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D6D5F35E25C88070008148B3 /* Assets.xcassets */; };
 		D6D5F36225C88070008148B3 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D6D5F36125C88070008148B3 /* Preview Assets.xcassets */; };
 		D6D5F36525C88070008148B3 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D6D5F36325C88070008148B3 /* LaunchScreen.storyboard */; };
+		D6F54EED2612452E000362D1 /* AnalyticsTrack+TargetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6F54EEC2612452E000362D1 /* AnalyticsTrack+TargetTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -184,6 +185,7 @@
 		D6D5F36125C88070008148B3 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		D6D5F36425C88070008148B3 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		D6D5F36625C88070008148B3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D6F54EEC2612452E000362D1 /* AnalyticsTrack+TargetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnalyticsTrack+TargetTests.swift"; sourceTree = "<group>"; };
 		E274320DD947E7BB2B2E8A33 /* Pods-AEPAnalyticsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AEPAnalyticsTests.release.xcconfig"; path = "Target Support Files/Pods-AEPAnalyticsTests/Pods-AEPAnalyticsTests.release.xcconfig"; sourceTree = "<group>"; };
 		EF12C9A6B24908684CC8EA6C /* Pods-AEPAnalytics.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AEPAnalytics.release.xcconfig"; path = "Target Support Files/Pods-AEPAnalytics/Pods-AEPAnalytics.release.xcconfig"; sourceTree = "<group>"; };
 		F09743C2FA04519BE26C974E /* Pods-AnalyticsSampleApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AnalyticsSampleApp.release.xcconfig"; path = "Target Support Files/Pods-AnalyticsSampleApp/Pods-AnalyticsSampleApp.release.xcconfig"; sourceTree = "<group>"; };
@@ -362,6 +364,7 @@
 				AC73D39125E6F4160068AB96 /* AnalyticsTrack+LifecycleTests.swift */,
 				AC73D39425E6F4160068AB96 /* AnalyticsTrack+PlacesTests.swift */,
 				AC73D39225E6F4160068AB96 /* AnalyticsTrackTests.swift */,
+				D6F54EEC2612452E000362D1 /* AnalyticsTrack+TargetTests.swift */,
 			);
 			path = FunctionalTests;
 			sourceTree = "<group>";
@@ -802,6 +805,7 @@
 				AC73D3E125E6F5060068AB96 /* MockNetworking.swift in Sources */,
 				AC73D3D025E6F5010068AB96 /* AnalyticsIDTests.swift in Sources */,
 				AC73D3D125E6F5010068AB96 /* AnalyticsTrack+AssuranceTests.swift in Sources */,
+				D6F54EED2612452E000362D1 /* AnalyticsTrack+TargetTests.swift in Sources */,
 				AC73D3D325E6F5010068AB96 /* AnalyticsFunctionalTestBase.swift in Sources */,
 				AC73D3E825E6F5060068AB96 /* MockDataQueuing.swift in Sources */,
 				AC26B11E25E76782008AC68F /* AnalyticsHitReorderTests.swift in Sources */,

--- a/AEPAnalytics/Sources/Analytics.swift
+++ b/AEPAnalytics/Sources/Analytics.swift
@@ -297,6 +297,14 @@ public class Analytics: NSObject, Extension {
             dispatchQueueSizeResponse(event: event, queueSize: queueSize)
         } else if eventData.keys.contains(AnalyticsConstants.EventDataKeys.FORCE_KICK_HITS) {
             analyticsDatabase?.kick(ignoreBatchLimit: true)
+        } else { // this is an internal track action / state event
+            let softDependencies: [String] = [
+                AnalyticsConstants.Lifecycle.EventDataKeys.SHARED_STATE_NAME,
+                AnalyticsConstants.Assurance.EventDataKeys.SHARED_STATE_NAME,
+                AnalyticsConstants.Places.EventDataKeys.SHARED_STATE_NAME
+            ]
+            updateAnalyticsState(forEvent: event, dependencies: analyticsHardDependencies + softDependencies)
+            handleTrackRequest(event: event, eventData: eventData)
         }
     }
 

--- a/AEPAnalytics/Sources/Analytics.swift
+++ b/AEPAnalytics/Sources/Analytics.swift
@@ -284,6 +284,13 @@ public class Analytics: NSObject, Extension {
         }
     }
 
+    /// Handles the following events
+    /// `EventType.analytics` and `EventSource.requestContent`
+    ///  The Analytics Request Content event can contain a clearQueue, getQueueSize, sendQueuedHits, or internal track event.
+    ///  If it is an internal track event, an internal track request will be queued containing the event's context data and action name.
+    ///  State data from the hard dependencies (Configuration and Identity) will be used when generating the request as well as state
+    ///  data from any soft dependencies present (Lifecycle, Assurance, or Places).
+    /// - Parameter event: The `Event` to be processed.
     private func handleAnalyticsRequestContentEvent(_ event: Event) {
         guard let eventData = event.data, !eventData.isEmpty else {
             Log.debug(label: LOG_TAG, "handleAnalyticsRequestContentEvent - Returning early, event data is nil or empty.")

--- a/AEPAnalytics/Tests/FunctionalTests/AnalyticsTrack+TargetTests.swift
+++ b/AEPAnalytics/Tests/FunctionalTests/AnalyticsTrack+TargetTests.swift
@@ -39,13 +39,28 @@ class AnalyticsTrack_TargetTests : AnalyticsFunctionalTestBase {
 
         waitForProcessing()
 
+        let expectedVars = [
+            "ce": "UTF-8",
+            "cp": "foreground",
+            "mid" : "mid",
+            "aamb" : "blob",
+            "aamlh" : "lochint",
+            "tnta" : "285408:0:0|2",
+            "pe" : "tnt",
+            "pev2" : "ADBINTERNAL:AnalyticsForTarget",
+            "ts" : String(event1.timestamp.getUnixTimeInSeconds())
+        ]
+
+        let expectedContextData = [
+            "a.internalaction" : "AnalyticsForTarget",
+            "a.target.sessionId" : "8E0988F2-57C7-42CA-B5A6-6458D370F315"
+        ]
+
+        // verify
         XCTAssertEqual(mockNetworkService?.calledNetworkRequests.count, 1)
-        let payload = mockNetworkService?.calledNetworkRequests[0]?.connectPayload ?? ""
-        let contextData = AnalyticsRequestHelper.getContextData(source: payload) as? [String: String]
-        XCTAssertEqual("AnalyticsForTarget", contextData?["a.internalaction"])
-        XCTAssertEqual("8E0988F2-57C7-42CA-B5A6-6458D370F315", contextData?["a.target.sessionId"])
-        XCTAssertTrue(payload.contains("tnta=285408%3A0%3A0%7C2"))
-        XCTAssertTrue(payload.contains("&pe=tnt"))
-        XCTAssertTrue(payload.contains("&pev2=ADBINTERNAL%3AAnalyticsForTarget"))
+        verifyHit(request: mockNetworkService?.calledNetworkRequests[0],
+                  host: "https://test.com/b/ss/rsid/0/",
+                  vars: expectedVars,
+                  contextData: expectedContextData)
     }
 }

--- a/AEPAnalytics/Tests/FunctionalTests/AnalyticsTrack+TargetTests.swift
+++ b/AEPAnalytics/Tests/FunctionalTests/AnalyticsTrack+TargetTests.swift
@@ -1,0 +1,51 @@
+/*
+ Copyright 2021 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import XCTest
+import AEPServices
+@testable import AEPAnalytics
+@testable import AEPCore
+
+class AnalyticsTrack_TargetTests : AnalyticsFunctionalTestBase {
+
+    override func setUp() {
+        super.setupBase()
+    }
+
+    // Analytics for target event triggers an internal analytics track action request
+    func testAnalyticsForTargetRequestEventTriggersA4TTrackAction() {
+        dispatchDefaultConfigAndIdentityStates()
+
+        let trackData: [String: Any] = [
+            AnalyticsConstants.EventDataKeys.TRACK_ACTION : "AnalyticsForTarget",
+            AnalyticsConstants.EventDataKeys.TRACK_INTERNAL: true,
+            AnalyticsConstants.EventDataKeys.CONTEXT_DATA : [
+                "&&tnta": "285408:0:0|2",
+                "&&pe": "tnt",
+                "a.target.sessionId" : "8E0988F2-57C7-42CA-B5A6-6458D370F315"
+            ]
+        ]
+        let event1 = Event(name: "A4T track action event", type: EventType.analytics, source: EventSource.requestContent, data: trackData)
+        mockRuntime.simulateComingEvent(event: event1)
+
+        waitForProcessing()
+
+        XCTAssertEqual(mockNetworkService?.calledNetworkRequests.count, 1)
+        let payload = mockNetworkService?.calledNetworkRequests[0]?.connectPayload ?? ""
+        let contextData = AnalyticsRequestHelper.getContextData(source: payload) as? [String: String]
+        XCTAssertEqual("AnalyticsForTarget", contextData?["a.internalaction"])
+        XCTAssertEqual("8E0988F2-57C7-42CA-B5A6-6458D370F315", contextData?["a.target.sessionId"])
+        XCTAssertTrue(payload.contains("tnta=285408%3A0%3A0%7C2"))
+        XCTAssertTrue(payload.contains("&pe=tnt"))
+        XCTAssertTrue(payload.contains("&pev2=ADBINTERNAL%3AAnalyticsForTarget"))
+    }
+}

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -56,19 +56,19 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   ACPCore:
-    :commit: 748779dd93ae14a9b7241c93fe9fd190abb816a5
+    :commit: deec3800bce117f7f760eb6644af4559489c2aae
     :git: https://github.com/adobe/aepsdk-compatibility-ios.git
   AEPCore:
-    :commit: 9fe655414c1e88d4252e9be25cf4f8d1dc539bee
+    :commit: 785daaed1c2a7553fdbcba9bfc885ae8a50b4702
     :git: https://github.com/adobe/aepsdk-core-ios.git
   AEPIdentity:
-    :commit: 9fe655414c1e88d4252e9be25cf4f8d1dc539bee
+    :commit: 785daaed1c2a7553fdbcba9bfc885ae8a50b4702
     :git: https://github.com/adobe/aepsdk-core-ios.git
   AEPRulesEngine:
     :commit: 1e270654b330b9f07a6b1ec374e686f2e631e039
     :git: https://github.com/adobe/aepsdk-rulesengine-ios.git
   AEPServices:
-    :commit: 9fe655414c1e88d4252e9be25cf4f8d1dc539bee
+    :commit: 785daaed1c2a7553fdbcba9bfc885ae8a50b4702
     :git: https://github.com/adobe/aepsdk-core-ios.git
 
 SPEC CHECKSUMS:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds support for sending track action or track state ping when the analytics extension receives an analytics request content event for an internal track.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
