### PR TITLE
Downmerge main to dev after script updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ orbs:
 jobs:
   build-and-test:
     macos:
-      xcode: 11.2.1 # Specify the Xcode version to use
+      xcode: 12.0.1 # Specify the Xcode version to use
 
     steps:
       - checkout
@@ -49,14 +49,6 @@ jobs:
       - run:
           name: Lint Source Code
           command: make lint
-
-      - run:
-          name: Install nicklockwood/SwiftFormat
-          command: brew install swiftformat
-
-      - run:
-          name: Swift Formating
-          command: swiftformat . --lint --swiftversion 5.2
 
       # pre-start the simulator to prevent timeouts
       - run:

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,2 +1,0 @@
---rules indent
---exclude Pods,Generated

--- a/AEPAnalytics.xcodeproj/project.pbxproj
+++ b/AEPAnalytics.xcodeproj/project.pbxproj
@@ -710,7 +710,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd ${PROJECT_DIR}\nif which swiftlint >/dev/null; then\n  ./Pods/SwiftLint/swiftlint\nelse\n  echo \"error: SwiftLint is not installed, please run the pod install command from the project root directory.\"\nfi\nif which swiftformat >/dev/null; then\n   swiftformat .\nelse\necho \"error: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat\"\nfi\n";
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\ncd ${PROJECT_DIR}\nif which ./Pods/SwiftLint/swiftlint >/dev/null; then\n    ./Pods/SwiftLint/swiftlint\nelse\n    echo \"error: SwiftLint not installed, please run the pod install command from the project root directory.\"\nfi\n";
 		};
 		B844C65C6320925C034AC42C /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/AEPAnalytics/Tests/TestHelper/TestableExtensionRuntime.swift
+++ b/AEPAnalytics/Tests/TestHelper/TestableExtensionRuntime.swift
@@ -24,6 +24,8 @@ class TestableExtensionRuntime: ExtensionRuntime {
     var otherXDMSharedStates: [String: SharedStateResult] = [:]
 
     let dispatchQueue = DispatchQueue(label: "")
+    
+    public func getHistoricalEvents(_ requests: [EventHistoryRequest], enforceOrder: Bool, handler: @escaping ([EventHistoryResult]) -> Void) {}
 
     func getListener(type: String, source: String) -> EventListener? {
         return listeners["\(type)-\(source)"]

--- a/Makefile
+++ b/Makefile
@@ -38,17 +38,11 @@ archive: pod-update
 clean:
 	rm -rf ./build
 
-format:
-	swiftformat . --swiftversion 5.1
-
 lint-autocorrect:
 	./Pods/SwiftLint/swiftlint autocorrect
 
 lint:
 	./Pods/SwiftLint/swiftlint lint
-
-checkFormat:
-		swiftformat . --lint --swiftversion 5.1
 
 # release checks
 check-version:

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,15 +2,15 @@ PODS:
   - AEPAssurance (3.0.0):
     - AEPCore (>= 3.1.0)
     - AEPServices (>= 3.1.0)
-  - AEPCore (3.3.1):
-    - AEPRulesEngine (= 1.0.1)
-    - AEPServices (= 3.3.1)
-  - AEPIdentity (3.3.1):
-    - AEPCore (= 3.3.1)
-  - AEPLifecycle (3.3.1):
-    - AEPCore (= 3.3.1)
-  - AEPRulesEngine (1.0.1)
-  - AEPServices (3.3.1)
+  - AEPCore (3.4.2):
+    - AEPRulesEngine (>= 1.1.0)
+    - AEPServices (>= 3.4.2)
+  - AEPIdentity (3.4.2):
+    - AEPCore (>= 3.4.2)
+  - AEPLifecycle (3.4.2):
+    - AEPCore (>= 3.4.2)
+  - AEPRulesEngine (1.1.0)
+  - AEPServices (3.4.2)
   - SwiftLint (0.44.0)
 
 DEPENDENCIES:
@@ -34,13 +34,13 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   AEPAssurance: 18068627111e366a851dc2166239f22b665101bd
-  AEPCore: fc1398728b6b2a4dcc8dc96455f69ec144e087c0
-  AEPIdentity: 40aedf425fc7cc63dde579135b8c1c65497a42d2
-  AEPLifecycle: dc131d6744a55d71bc9009d65f3b3428645cbd23
-  AEPRulesEngine: 5075ed294026a12e37bd26fe260f74604d205354
-  AEPServices: c49e7b6ef17ec9f874b015f68ac7d2436235282f
+  AEPCore: b01856bf24972e4720cb0511a358d1e68067252a
+  AEPIdentity: fbf755560afcbb0acd66cd5b6a1c147530fca5f6
+  AEPLifecycle: 1e0e843465fb143f8d8949dcf06de169d5c26f62
+  AEPRulesEngine: bb2927ed5501ddf9754c66e97f8d2b1cf8e33b19
+  AEPServices: 3214311f239c8cdc6267d757200b05ec0ab05878
   SwiftLint: e96c0a8c770c7ebbc4d36c55baf9096bb65c4584
 
 PODFILE CHECKSUM: 6a829fa8845ca92c3c86857bb7c8469ca0ecc1a2
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.11.2


### PR DESCRIPTION
Scripts were updated directly to Main. Downmerge changes to dev.

* Remove SwiftFormat from project.
As SwiftFormat is not automatically installed like SwiftLint is, customers can get build failures.

* Add required 'getHistoricalEvents' method to TestableExtensionRuntime

* Remove leading whitespace from run script.

* Update CircleCI Xcode image to 12.0.1

* Remove SwiftFormat

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
