### PR TITLE
[MOB-15980] Fixed getTrackingIdentifier and getVisitorIdentifier to return nil string and not return unexpected error when aid vid values are not found.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ orbs:
 jobs:
   build-and-test:
     macos:
-      xcode: 11.2.1 # Specify the Xcode version to use
+      xcode: 12.0.1 # Specify the Xcode version to use
 
     steps:
       - checkout

--- a/AEPAnalytics/Sources/Analytics+PublicAPI.swift
+++ b/AEPAnalytics/Sources/Analytics+PublicAPI.swift
@@ -65,8 +65,18 @@ import Foundation
                 return
             }
 
-            let trackingIdentifier = responseEvent.data?[AnalyticsConstants.EventDataKeys.ANALYTICS_ID] as? String
-            completion(trackingIdentifier, nil)
+            if let responseData = responseEvent.data {
+                if responseData.keys.contains(AnalyticsConstants.EventDataKeys.ANALYTICS_ID) {
+                    guard let trackingIdentifier = responseData[AnalyticsConstants.EventDataKeys.ANALYTICS_ID] as? String else {
+                        completion(nil, AEPError.unexpected)
+                        return
+                    }
+                    completion(trackingIdentifier, nil)
+                    return
+                }
+            }
+
+            completion(nil, nil)
         }
     }
     /// Retrieves the visitor tracking identifier.
@@ -82,8 +92,18 @@ import Foundation
                 return
             }
 
-            let visitorIdentifier = responseEvent.data?[AnalyticsConstants.EventDataKeys.VISITOR_IDENTIFIER] as? String
-            completion(visitorIdentifier, nil)
+            if let responseData = responseEvent.data {
+                if responseData.keys.contains(AnalyticsConstants.EventDataKeys.VISITOR_IDENTIFIER) {
+                    guard let visitorIdentifier = responseData[AnalyticsConstants.EventDataKeys.VISITOR_IDENTIFIER] as? String else {
+                        completion(nil, AEPError.unexpected)
+                        return
+                    }
+                    completion(visitorIdentifier, nil)
+                    return
+                }
+            }
+
+            completion(nil, nil)
         }
     }
     /// Sets the visitor tracking identifier.

--- a/AEPAnalytics/Sources/Analytics+PublicAPI.swift
+++ b/AEPAnalytics/Sources/Analytics+PublicAPI.swift
@@ -65,10 +65,7 @@ import Foundation
                 return
             }
 
-            guard let trackingIdentifier = responseEvent.data?[AnalyticsConstants.EventDataKeys.ANALYTICS_ID] as? String else {
-                completion(nil, AEPError.unexpected)
-                return
-            }
+            let trackingIdentifier = responseEvent.data?[AnalyticsConstants.EventDataKeys.ANALYTICS_ID] as? String
             completion(trackingIdentifier, nil)
         }
     }
@@ -85,10 +82,7 @@ import Foundation
                 return
             }
 
-            guard let visitorIdentifier = responseEvent.data?[AnalyticsConstants.EventDataKeys.VISITOR_IDENTIFIER] as? String else {
-                completion(nil, AEPError.unexpected)
-                return
-            }
+            let visitorIdentifier = responseEvent.data?[AnalyticsConstants.EventDataKeys.VISITOR_IDENTIFIER] as? String
             completion(visitorIdentifier, nil)
         }
     }

--- a/AEPAnalytics/Sources/Analytics+PublicAPI.swift
+++ b/AEPAnalytics/Sources/Analytics+PublicAPI.swift
@@ -65,15 +65,13 @@ import Foundation
                 return
             }
 
-            if let responseData = responseEvent.data {
-                if responseData.keys.contains(AnalyticsConstants.EventDataKeys.ANALYTICS_ID) {
-                    guard let trackingIdentifier = responseData[AnalyticsConstants.EventDataKeys.ANALYTICS_ID] as? String else {
-                        completion(nil, AEPError.unexpected)
-                        return
-                    }
-                    completion(trackingIdentifier, nil)
+            if let responseData = responseEvent.data, responseData.keys.contains(AnalyticsConstants.EventDataKeys.ANALYTICS_ID) {
+                guard let trackingIdentifier = responseData[AnalyticsConstants.EventDataKeys.ANALYTICS_ID] as? String else {
+                    completion(nil, AEPError.unexpected)
                     return
                 }
+                completion(trackingIdentifier, nil)
+                return
             }
 
             completion(nil, nil)
@@ -92,15 +90,13 @@ import Foundation
                 return
             }
 
-            if let responseData = responseEvent.data {
-                if responseData.keys.contains(AnalyticsConstants.EventDataKeys.VISITOR_IDENTIFIER) {
-                    guard let visitorIdentifier = responseData[AnalyticsConstants.EventDataKeys.VISITOR_IDENTIFIER] as? String else {
-                        completion(nil, AEPError.unexpected)
-                        return
-                    }
-                    completion(visitorIdentifier, nil)
+            if let responseData = responseEvent.data, responseData.keys.contains(AnalyticsConstants.EventDataKeys.VISITOR_IDENTIFIER) {
+                guard let visitorIdentifier = responseData[AnalyticsConstants.EventDataKeys.VISITOR_IDENTIFIER] as? String else {
+                    completion(nil, AEPError.unexpected)
                     return
                 }
+                completion(visitorIdentifier, nil)
+                return
             }
 
             completion(nil, nil)

--- a/AEPAnalytics/Tests/UnitTests/AnalyticsAPITests.swift
+++ b/AEPAnalytics/Tests/UnitTests/AnalyticsAPITests.swift
@@ -189,7 +189,7 @@ class AnalyticsAPITests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
-    func testGetTrackingIdentifier_IncorrectResponse() {
+    func testGetTrackingIdentifier_MissingIdentifierInResponse() {
         // setup
         let expectation = XCTestExpectation(description: "getTrackingIdentifier should return error with invalid response")
         expectation.assertForOverFulfill = true
@@ -203,6 +203,30 @@ class AnalyticsAPITests: XCTestCase {
         Analytics.getTrackingIdentifier(){(identifier, error) in
             XCTAssertNil(identifier)
             XCTAssertNil(error)
+            expectation.fulfill()
+        }
+
+        // verify
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func testGetTrackingIdentifier_IncorrectResponse() {
+        // setup
+        let expectation = XCTestExpectation(description: "getTrackingIdentifier should return error with invalid response")
+        expectation.assertForOverFulfill = true
+
+        EventHub.shared.getExtensionContainer(MockExtension.self)?.registerListener(type: EventType.analytics, source: EventSource.requestIdentity) { (event) in
+            let responseData = [
+                AnalyticsTestConstants.EventDataKeys.ANALYTICS_ID: 12345
+            ]
+            let responseEvent = event.createResponseEvent(name: "ResponseEvent", type: EventType.analytics, source: EventSource.responseContent, data: responseData)
+            EventHub.shared.dispatch(event: responseEvent)
+        }
+
+        // test
+        Analytics.getTrackingIdentifier(){(identifier, error) in
+            XCTAssertNil(identifier)
+            XCTAssertEqual(error as? AEPError, .unexpected)
             expectation.fulfill()
         }
 
@@ -283,7 +307,7 @@ class AnalyticsAPITests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
-    func testGetVisitorIdentifier_IncorrectResponse() {
+    func testGetVisitorIdentifier_MissingIdentifierInResponse() {
         // setup
         let expectation = XCTestExpectation(description: "getVisitoridentifier should return error with invalid response")
         expectation.assertForOverFulfill = true
@@ -303,6 +327,31 @@ class AnalyticsAPITests: XCTestCase {
         // verify
         wait(for: [expectation], timeout: 1.0)
     }
+
+    func testGetVisitorIdentifier_IncorrectResponse() {
+        // setup
+        let expectation = XCTestExpectation(description: "getVisitoridentifier should return error with invalid response")
+        expectation.assertForOverFulfill = true
+
+        EventHub.shared.getExtensionContainer(MockExtension.self)?.registerListener(type: EventType.analytics, source: EventSource.requestIdentity) { (event) in
+            let responseData = [
+                AnalyticsTestConstants.EventDataKeys.VISITOR_IDENTIFIER: 12345
+            ]
+            let responseEvent = event.createResponseEvent(name: "ResponseEvent", type: EventType.analytics, source: EventSource.responseContent, data: responseData)
+            EventHub.shared.dispatch(event: responseEvent)
+        }
+
+        // test
+        Analytics.getVisitorIdentifier(){(identifier, error) in
+            XCTAssertNil(identifier)
+            XCTAssertEqual(error as? AEPError, .unexpected)
+            expectation.fulfill()
+        }
+
+        // verify
+        wait(for: [expectation], timeout: 1.0)
+    }
+
 
     func testGetVisitorIdentifier_Timeout() {
         // setup

--- a/AEPAnalytics/Tests/UnitTests/AnalyticsAPITests.swift
+++ b/AEPAnalytics/Tests/UnitTests/AnalyticsAPITests.swift
@@ -202,7 +202,7 @@ class AnalyticsAPITests: XCTestCase {
         // test
         Analytics.getTrackingIdentifier(){(identifier, error) in
             XCTAssertNil(identifier)
-            XCTAssertEqual(error as? AEPError, .unexpected)
+            XCTAssertNil(error)
             expectation.fulfill()
         }
 
@@ -296,7 +296,7 @@ class AnalyticsAPITests: XCTestCase {
         // test
         Analytics.getVisitorIdentifier(){(identifier, error) in
             XCTAssertNil(identifier)
-            XCTAssertEqual(error as? AEPError, .unexpected)
+            XCTAssertNil(error)
             expectation.fulfill()
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
