### PR TITLE
Coverage fix for Xcode 12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
       # pre-start the simulator to prevent timeouts
       - run:
           name: Pre-start Simulator
-          command: xcrun instruments -w "iPhone 8 (13.5) [" || true
+          command: xcrun instruments -w "iPhone 8 (13.1) [" || true
 
       - run:
           name: Run Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,9 @@ jobs:
       # restore pods related caches
       - restore_cache:
           keys:
-            - cocoapods-cache-v4-{{ arch }}-{{ .Branch }}-{{ checksum "Podfile.lock" }}
-            - cocoapods-cache-v4-{{ arch }}-{{ .Branch }}
-            - cocoapods-cache-v4
+            - cocoapods-cache-v5-{{ arch }}-{{ .Branch }}-{{ checksum "Podfile.lock" }}
+            - cocoapods-cache-v5-{{ arch }}-{{ .Branch }}
+            - cocoapods-cache-v5
             - 1-gems-{{ checksum "Gemfile.lock" }}
 
       # install Gemfile
@@ -40,7 +40,7 @@ jobs:
       # save pods related files
       - save_cache:
           name: Saving CocoaPods Cache
-          key: cocoapods-cache-v4-{{ arch }}-{{ .Branch }}-{{ checksum "Podfile.lock" }}
+          key: cocoapods-cache-v5-{{ arch }}-{{ .Branch }}-{{ checksum "Podfile.lock" }}
           paths:
             - ./Pods
             - ~/.cocoapods

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
       # pre-start the simulator to prevent timeouts
       - run:
           name: Pre-start Simulator
-          command: xcrun instruments -w "iPhone 8 (13.1) [" || true
+          command: xcrun instruments -w "iPhone 8 (13.5) [" || true
 
       - run:
           name: Run Tests

--- a/AEPAnalytics.xcodeproj/project.pbxproj
+++ b/AEPAnalytics.xcodeproj/project.pbxproj
@@ -1064,7 +1064,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7F67C440D2E79632BFEE85A7 /* Pods-AEPAnalyticsUnitTests.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = FKGEE875K4;
@@ -1088,7 +1087,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 4FB729EA9494DA855AD93AA6 /* Pods-AEPAnalyticsUnitTests.release.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = FKGEE875K4;

--- a/AEPAnalytics.xcodeproj/project.pbxproj
+++ b/AEPAnalytics.xcodeproj/project.pbxproj
@@ -1081,7 +1081,6 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TVOS_DEPLOYMENT_TARGET = 10.0;
 			};
 			name = Debug;
 		};
@@ -1105,7 +1104,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TVOS_DEPLOYMENT_TARGET = 10.0;
 			};
 			name = Release;
 		};
@@ -1115,7 +1113,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = AEPAnalytics/Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1134,7 +1132,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = AEPAnalytics/Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/AEPAnalytics.xcodeproj/xcshareddata/xcschemes/AEPAnalytics.xcscheme
+++ b/AEPAnalytics.xcodeproj/xcshareddata/xcschemes/AEPAnalytics.xcscheme
@@ -40,7 +40,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/AEPAnalytics/Tests/TestHelper/TestableExtensionRuntime.swift
+++ b/AEPAnalytics/Tests/TestHelper/TestableExtensionRuntime.swift
@@ -16,6 +16,10 @@ import Foundation
 
 
 class TestableExtensionRuntime: ExtensionRuntime {
+    func getHistoricalEvents(_ requests: [EventHistoryRequest], enforceOrder: Bool, handler: @escaping ([EventHistoryResult]) -> Void) {
+        // no-op
+    }
+
     var listeners: [String: EventListener] = [:]
     var dispatchedEvents: [Event] = []
     var createdSharedStates: [[String: Any]?] = []

--- a/AEPAnalytics/Tests/TestHelper/TestableExtensionRuntime.swift
+++ b/AEPAnalytics/Tests/TestHelper/TestableExtensionRuntime.swift
@@ -16,9 +16,6 @@ import Foundation
 
 
 class TestableExtensionRuntime: ExtensionRuntime {
-    func getHistoricalEvents(_ requests: [EventHistoryRequest], enforceOrder: Bool, handler: @escaping ([EventHistoryResult]) -> Void) {
-        // no-op
-    }
 
     var listeners: [String: EventListener] = [:]
     var dispatchedEvents: [Event] = []

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - AEPAssurance (3.0.0):
+  - AEPAssurance (3.0.1):
     - AEPCore (>= 3.1.0)
     - AEPServices (>= 3.1.0)
   - AEPCore (3.4.2):
@@ -33,7 +33,7 @@ SPEC REPOS:
     - SwiftLint
 
 SPEC CHECKSUMS:
-  AEPAssurance: 18068627111e366a851dc2166239f22b665101bd
+  AEPAssurance: b25880cd4b14f22c61a1dce19807bd0ca0fe9b17
   AEPCore: b01856bf24972e4720cb0511a358d1e68067252a
   AEPIdentity: fbf755560afcbb0acd66cd5b6a1c147530fca5f6
   AEPLifecycle: 1e0e843465fb143f8d8949dcf06de169d5c26f62

--- a/codecov.yml
+++ b/codecov.yml
@@ -22,7 +22,9 @@ coverage:
     - "./AEPAnalytics/Mocks/**/*"
     - "./AEPAnalytics/Tests/**/*"
     - "./AEPAnalytics/Tests/.*"
-    - "./AnalyticsSampleApp/.*"
+    - "./AnalyticsSampleApp"
+    - "./Documentation"
+    - "./Script" 
     - "./build"
 
 parsers:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
After updating CircleCI to run on Xcode 12, the functional tests failed to execute and the total code coverage report was only including the unit tests results, failing with:
```
warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 14.1, but the range of supported deployment target versions is 9.0 to 14.0.99. (in target 'AEPAnalyticsFunctionalTests' from project 'AEPAnalytics')
```
Changed all the test targets to iOS 10.0

## Related Issue
https://github.com/CocoaPods/CocoaPods/issues/9884
https://github.com/CocoaPods/CocoaPods/issues/9936

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
