### PR TITLE
Add Empty check for trackState and trackAction scenarios

### DIFF
--- a/AEPAnalytics/Sources/Analytics.swift
+++ b/AEPAnalytics/Sources/Analytics.swift
@@ -592,14 +592,14 @@ public class AnalyticsBase: NSObject, Extension {
             return analyticsVars
         }
 
-        if let actionName = trackData[AnalyticsConstants.EventDataKeys.TRACK_ACTION] as? String {
+        if let actionName = trackData[AnalyticsConstants.EventDataKeys.TRACK_ACTION] as? String, !actionName.isEmpty {
             analyticsVars[AnalyticsConstants.Request.IGNORE_PAGE_NAME_KEY] = AnalyticsConstants.IGNORE_PAGE_NAME_VALUE
             let isInternal = trackData[AnalyticsConstants.EventDataKeys.TRACK_INTERNAL] as? Bool ?? false
             let actionNameWithPrefix = "\(isInternal ? AnalyticsConstants.INTERNAL_ACTION_PREFIX : AnalyticsConstants.ACTION_PREFIX)\(actionName)"
             analyticsVars[AnalyticsConstants.Request.ACTION_NAME_KEY] = actionNameWithPrefix
         }
         analyticsVars[AnalyticsConstants.Request.PAGE_NAME_KEY] = analyticsState.applicationId
-        if let stateName = trackData[AnalyticsConstants.EventDataKeys.TRACK_STATE] as? String {
+        if let stateName = trackData[AnalyticsConstants.EventDataKeys.TRACK_STATE] as? String, !stateName.isEmpty {
             analyticsVars[AnalyticsConstants.Request.PAGE_NAME_KEY] = stateName
         }
 

--- a/AEPAnalytics/Tests/FunctionalTests/AnalyticsAppExtTrackTests.swift
+++ b/AEPAnalytics/Tests/FunctionalTests/AnalyticsAppExtTrackTests.swift
@@ -28,10 +28,17 @@ class AnalyticsAppExtTrackTests : AnalyticsTrackTestBase {
         trackStateTester()
     }
 
+    func testTrackEmptyState() {
+        trackStateEmptyTester()
+    }
+    
     func testTrackAction() {
         trackActionTester()
     }
 
+    func testTrackEmptyAction() {
+        trackActionEmptyTester()
+    }
 
     func testTrackInternalAction() {
         trackInternalActionTester()

--- a/AEPAnalytics/Tests/FunctionalTests/AnalyticsTrackTestBase.swift
+++ b/AEPAnalytics/Tests/FunctionalTests/AnalyticsTrackTestBase.swift
@@ -66,6 +66,61 @@ class AnalyticsTrackTestBase : AnalyticsFunctionalTestBase {
                   contextData: expectedContextData)
     }
 
+     func trackStateEmptyTester() {
+        let lifecycleSharedState: [String: Any] = [
+            AnalyticsTestConstants.Lifecycle.EventDataKeys.LIFECYCLE_CONTEXT_DATA : [
+                AnalyticsTestConstants.Lifecycle.EventDataKeys.APP_ID : "mockAppName",
+            ]
+        ]
+
+        simulateLifecycleState(data: lifecycleSharedState)
+        
+        let trackData: [String: Any] = [
+            CoreConstants.Keys.STATE : CoreConstants.Keys.STATE.isEmpty,
+            CoreConstants.Keys.CONTEXT_DATA : [
+                "k1": "v1",
+                "k2": "v2"
+            ]
+        ]
+        let trackEvent = Event(name: "Generic track event", type: EventType.genericTrack, source: EventSource.requestContent, data: trackData)
+        mockRuntime.simulateComingEvent(event: trackEvent)
+
+        waitForProcessing()
+        let expectedVars: [String: String]
+        if runningForApp {
+            expectedVars = [
+                "ce": "UTF-8",
+                "cp": "foreground",
+                "pageName" : "mockAppName",
+                "mid" : "mid",
+                "aamb" : "blob",
+                "aamlh" : "lochint",
+                "ts" : String(trackEvent.timestamp.getUnixTimeInSeconds())
+            ]
+        } else {
+            expectedVars = [
+                "ce": "UTF-8",
+                "pageName" : "mockAppName",
+                "mid" : "mid",
+                "aamb" : "blob",
+                "aamlh" : "lochint",
+                "ts" : String(trackEvent.timestamp.getUnixTimeInSeconds())
+            ]
+        }
+
+        let expectedContextData = [
+            "k1" : "v1",
+            "k2" : "v2",
+            "a.AppID" : "mockAppName"
+        ]
+
+        XCTAssertEqual(mockNetworkService?.calledNetworkRequests.count, 1)
+        verifyHit(request: mockNetworkService?.calledNetworkRequests[0],
+                  host: "https://test.com/b/ss/rsid/0/",
+                  vars: expectedVars,
+                  contextData: expectedContextData)
+    }
+
     func trackActionTester() {
         let trackData: [String: Any] = [
             CoreConstants.Keys.ACTION : "testAction",
@@ -115,6 +170,62 @@ class AnalyticsTrackTestBase : AnalyticsFunctionalTestBase {
                   contextData: expectedContextData)
     }
 
+    func trackActionEmptyTester() {
+        
+        let lifecycleSharedState: [String: Any] = [
+            AnalyticsTestConstants.Lifecycle.EventDataKeys.LIFECYCLE_CONTEXT_DATA : [
+                AnalyticsTestConstants.Lifecycle.EventDataKeys.APP_ID : "mockAppName",
+            ]
+        ]
+
+        simulateLifecycleState(data: lifecycleSharedState)
+                      
+        let trackData: [String: Any] = [
+            CoreConstants.Keys.ACTION : CoreConstants.Keys.ACTION.isEmpty,
+            CoreConstants.Keys.CONTEXT_DATA : [
+                "k1": "v1",
+                "k2": "v2"
+            ]
+        ]
+        let trackEvent = Event(name: "Generic track event", type: EventType.genericTrack, source: EventSource.requestContent, data: trackData)
+        mockRuntime.simulateComingEvent(event: trackEvent)
+
+        waitForProcessing()
+        let expectedVars: [String: String]
+        if runningForApp {
+            expectedVars = [
+                //no pev2 and pe
+                "ce": "UTF-8",
+                "cp": "foreground",
+                "pageName" : "mockAppName",
+                "mid" : "mid",
+                "aamb" : "blob",
+                "aamlh" : "lochint",
+                "ts" : String(trackEvent.timestamp.getUnixTimeInSeconds())
+            ]
+        } else {
+            expectedVars = [
+                "ce": "UTF-8",
+                "mid" : "mid",
+                "pageName" : "mockAppName",
+                "aamb" : "blob",
+                "aamlh" : "lochint",
+                "ts" : String(trackEvent.timestamp.getUnixTimeInSeconds())
+            ]
+        }
+
+        let expectedContextData = [
+            "k1" : "v1",
+            "k2" : "v2",
+            "a.AppID" : "mockAppName"
+        ]
+
+        XCTAssertEqual(mockNetworkService?.calledNetworkRequests.count, 1)
+        verifyHit(request: mockNetworkService?.calledNetworkRequests[0],
+                  host: "https://test.com/b/ss/rsid/0/",
+                  vars: expectedVars,
+                  contextData: expectedContextData)
+    }
 
     func trackInternalActionTester() {
         let trackData: [String: Any] = [

--- a/AEPAnalytics/Tests/FunctionalTests/AnalyticsTrackTests.swift
+++ b/AEPAnalytics/Tests/FunctionalTests/AnalyticsTrackTests.swift
@@ -28,11 +28,18 @@ class AnalyticsTrackTests : AnalyticsTrackTestBase {
         trackStateTester()
     }
 
+    func testTrackEmptyState() {
+    trackStateEmptyTester()
+    }
+
     func testTrackAction() {
         trackActionTester()
     }
 
-
+    func testTrackEmptyAction() {
+        trackActionEmptyTester()
+    }
+    
     func testTrackInternalAction() {
         trackInternalActionTester()
     }

--- a/AEPAnalytics/Tests/FunctionalTests/AnalyticsTrackTests.swift
+++ b/AEPAnalytics/Tests/FunctionalTests/AnalyticsTrackTests.swift
@@ -29,7 +29,7 @@ class AnalyticsTrackTests : AnalyticsTrackTestBase {
     }
 
     func testTrackEmptyState() {
-    trackStateEmptyTester()
+        trackStateEmptyTester()
     }
 
     func testTrackAction() {
@@ -43,7 +43,7 @@ class AnalyticsTrackTests : AnalyticsTrackTestBase {
     func testTrackInternalAction() {
         trackInternalActionTester()
     }
-
+    
     func testTrackOnlyContextData() {
         trackOnlyContextDataTester()
     }


### PR DESCRIPTION
Add Empty check for trackState and trackAction scenarios. 
When the state is empty, set the default page name to client app id.
Add tests.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
