### PR TITLE
update circleci + workflows for v5.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@
 version: 2.1
 
 orbs:
-  codecov: codecov/codecov@3.2.5
+  # codecov: codecov/codecov@3.2.5
   macos: circleci/macos@2
 
 # Workflows orchestrate a set of jobs to be run;
@@ -68,21 +68,21 @@ commands:
     steps:
       - macos/preboot-simulator:
           platform: "iOS"
-          version: "17.0"
+          version: "17.2"
           device: "iPhone 15"
 
   prestart_tvos_simulator:
     steps:
       - macos/preboot-simulator:
           platform: "tvOS"
-          version: "17.0"
+          version: "17.2"
           device: "Apple TV"
 
 
 jobs:
   validate-code:
     macos:
-      xcode: 15.0.0 # Specify the Xcode version to use
+      xcode: 15.1.0 # Specify the Xcode version to use
 
     steps:
       - checkout
@@ -95,7 +95,7 @@ jobs:
 
   test-ios:
     macos:
-      xcode: 15.0.0 # Specify the Xcode version to use
+      xcode: 15.1.0 # Specify the Xcode version to use
 
     steps:
       - checkout
@@ -110,14 +110,14 @@ jobs:
 
       # Code coverage upload using Codecov
       # See options explanation here: https://docs.codecov.com/docs/codecov-uploader
-      - codecov/upload:
-          flags: ios-tests
-          upload_name: Coverage Report for iOS Tests
-          xtra_args: -c -v --xc --xp iosresults.xcresult
+      # - codecov/upload:
+      #     flags: ios-tests
+      #     upload_name: Coverage Report for iOS Tests
+      #     xtra_args: -c -v --xc --xp iosresults.xcresult
   
   test-tvos:
     macos:
-      xcode: 15.0.0 # Specify the Xcode version to use
+      xcode: 15.1.0 # Specify the Xcode version to use
 
     steps:
       - checkout
@@ -132,14 +132,14 @@ jobs:
 
       # Code coverage upload using Codecov
       # See options explanation here: https://docs.codecov.com/docs/codecov-uploader
-      - codecov/upload:
-          flags: tvos-tests
-          upload_name: Coverage Report for tvOS Tests
-          xtra_args: -c -v --xc --xp tvosresults.xcresult
+      # - codecov/upload:
+      #     flags: tvos-tests
+      #     upload_name: Coverage Report for tvOS Tests
+      #     xtra_args: -c -v --xc --xp tvosresults.xcresult
 
   build_xcframework_and_app:  
     macos:
-      xcode: 15.0.0 # Specify the Xcode version to use
+      xcode: 15.1.0 # Specify the Xcode version to use
     
     steps:
       - checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         ref: main
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '15.0'
+        xcode-version: '15.0.1'
     
     - name: Install jq
       run: brew install jq


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- Use Xcode 15.1 for circleci build/tests which seems to be more stable and has better performance than 15.0.0 and 15.0.1.
- Disable codecov orb and codecov upload due to failure on signature validation step with xcode 15 (issue filed codecov-circleci-orb/issues/185)
- Update Xcode 15.0.1 in workflow

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
