### PR TITLE
Add logic to retry only for limited list of recoverable URLErrors

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -25,5 +25,5 @@ analyzer_rules:
 - unused_import
 
 function_body_length:
-    warning: 60
+    warning: 50
     error: 150

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -25,5 +25,5 @@ analyzer_rules:
 - unused_import
 
 function_body_length:
-    warning: 50
+    warning: 60
     error: 150

--- a/AEPAnalytics.podspec
+++ b/AEPAnalytics.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { 'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES' }
 
   s.dependency 'AEPCore', '>= 5.0.0', '< 6.0.0'
-  s.dependency 'AEPServices', '>= 5.0.0', '< 6.0.0'
+  s.dependency 'AEPServices', '>= 5.1.0', '< 6.0.0'
 
   s.source_files          = 'AEPAnalytics/Sources/*.swift'
 

--- a/AEPAnalytics/Sources/AnalyticsHitProcessor.swift
+++ b/AEPAnalytics/Sources/AnalyticsHitProcessor.swift
@@ -43,6 +43,23 @@ class AnalyticsHitProcessor: HitProcessing {
         return retryInterval
     }
 
+    private func shouldDropHit(timestamp: TimeInterval) -> Bool {
+        // If reset Identities was called, do not process the hit queued before reset identities was called.
+        if timestamp < self.analyticsState.lastResetIdentitiesTimestamp {
+            Log.debug(label: self.LOG_TAG, "\(#function) - Dropping Analytics hit, resetIdentities API was called after this request.")
+            return true
+        }
+
+        // If offline tracking is disabled, drop hits whose timestamp exceeds the offline disabled wait threshold
+        if !self.analyticsState.offlineEnabled &&
+            timestamp < (Date().timeIntervalSince1970 - AnalyticsConstants.Default.TIMESTAMP_DISABLED_WAIT_THRESHOLD_SECONDS) {
+            Log.debug(label: self.LOG_TAG, "\(#function) - Dropping Analytics hit, timestamp exceeds offline disabled wait threshold")
+            return true
+        }
+
+        return false
+    }
+
     func processHit(entity: DataEntity, completion: @escaping (Bool) -> Void) {
         guard let data = entity.data, let analyticsHit = try? JSONDecoder().decode(AnalyticsHit.self, from: data) else {
             // Failed to convert data to hit, unrecoverable error, move to next hit
@@ -57,17 +74,7 @@ class AnalyticsHitProcessor: HitProcessing {
             var payload = analyticsHit.payload
             var timestamp = analyticsHit.timestamp
 
-            // If reset Identities was called, do not process the hit queued before reset identities was called.
-            if timestamp < self.analyticsState.lastResetIdentitiesTimestamp {
-                Log.debug(label: self.LOG_TAG, "\(#function) - Dropping Analytics hit, resetIdentities API was called after this request.")
-                completion(true)
-                return
-            }
-
-            // If offline tracking is disabled, drop hits whose timestamp exceeds the offline disabled wait threshold
-            if !self.analyticsState.offlineEnabled &&
-                timestamp < (Date().timeIntervalSince1970 - AnalyticsConstants.Default.TIMESTAMP_DISABLED_WAIT_THRESHOLD_SECONDS) {
-                Log.debug(label: self.LOG_TAG, "\(#function) - Dropping Analytics hit, timestamp exceeds offline disabled wait threshold")
+            if shouldDropHit(timestamp: timestamp) {
                 completion(true)
                 return
             }
@@ -121,7 +128,8 @@ class AnalyticsHitProcessor: HitProcessing {
 
     /// Handles the network response after a hit has been sent to the server
     /// - Parameters:
-    ///   - entity: the data entity responsible for the hit
+    ///   - url: the url of the hit that was sent
+    ///   - hit: instance of the `AnalyticsHit` that was sent
     ///   - connection: the connection returned after we make the network request
     ///   - completion: a completion block to invoke after we have handled the network response with true for success and false for failure (retry)
     private func handleNetworkResponse(url: URL, hit: AnalyticsHit, connection: HttpConnection, completion: @escaping (Bool) -> Void) {
@@ -129,23 +137,7 @@ class AnalyticsHitProcessor: HitProcessing {
             // Hit sent successfully
             Log.debug(label: LOG_TAG, "\(#function) - Analytics hit request with url \(url.absoluteString) and payload \(hit.payload) sent successfully")
 
-            let contentType = connection.responseHttpHeader(forKey: AnalyticsConstants.Assurance.EventDataKeys.CONTENT_TYPE_HEADER)
-            let eTag = connection.responseHttpHeader(forKey: AnalyticsConstants.Assurance.EventDataKeys.ETAG_HEADER)
-            let serverHeader = connection.responseHttpHeader(forKey: AnalyticsConstants.Assurance.EventDataKeys.SERVER_HEADER)
-
-            let httpHeaders = [
-                AnalyticsConstants.EventDataKeys.CONTENT_TYPE_HEADER: contentType,
-                AnalyticsConstants.EventDataKeys.ETAG_HEADER: eTag,
-                AnalyticsConstants.EventDataKeys.SERVER_HEADER: serverHeader
-            ]
-
-            let eventData: [String: Any] = [
-                AnalyticsConstants.EventDataKeys.ANALYTICS_SERVER_RESPONSE: (connection.responseString ?? ""),
-                AnalyticsConstants.EventDataKeys.HEADERS_RESPONSE: httpHeaders,
-                AnalyticsConstants.EventDataKeys.HIT_URL: hit.payload,
-                AnalyticsConstants.EventDataKeys.HIT_HOST: url.absoluteString,
-                AnalyticsConstants.EventDataKeys.REQUEST_EVENT_IDENTIFIER: hit.eventIdentifier
-            ]
+            let eventData: [String: Any] = getResponseEventData(url: url, hit: hit, connection: connection)
 
             dispatchQueue.async { [weak self] in
                 guard let self = self else { return }
@@ -184,6 +176,34 @@ class AnalyticsHitProcessor: HitProcessing {
             completion(true) // don't retry
             return
         }
+    }
+
+    /// Create event data for Analytics response event from server
+    /// - Parameters:
+    ///   - url: the url of the hit that was sent
+    ///   - hit: instance of the `AnalyticsHit` that was sent
+    ///   - connection: the connection returned after we make the network request
+    /// - Returns: a dictionary containing the event data for the response event
+    private func getResponseEventData(url: URL, hit: AnalyticsHit, connection: HttpConnection) -> [String: Any] {
+        let contentType = connection.responseHttpHeader(forKey: AnalyticsConstants.Assurance.EventDataKeys.CONTENT_TYPE_HEADER)
+        let eTag = connection.responseHttpHeader(forKey: AnalyticsConstants.Assurance.EventDataKeys.ETAG_HEADER)
+        let serverHeader = connection.responseHttpHeader(forKey: AnalyticsConstants.Assurance.EventDataKeys.SERVER_HEADER)
+
+        let httpHeaders = [
+            AnalyticsConstants.EventDataKeys.CONTENT_TYPE_HEADER: contentType,
+            AnalyticsConstants.EventDataKeys.ETAG_HEADER: eTag,
+            AnalyticsConstants.EventDataKeys.SERVER_HEADER: serverHeader
+        ]
+
+        let eventData: [String: Any] = [
+            AnalyticsConstants.EventDataKeys.ANALYTICS_SERVER_RESPONSE: (connection.responseString ?? ""),
+            AnalyticsConstants.EventDataKeys.HEADERS_RESPONSE: httpHeaders,
+            AnalyticsConstants.EventDataKeys.HIT_URL: hit.payload,
+            AnalyticsConstants.EventDataKeys.HIT_HOST: url.absoluteString,
+            AnalyticsConstants.EventDataKeys.REQUEST_EVENT_IDENTIFIER: hit.eventIdentifier
+        ]
+
+        return eventData
     }
 
     private func replaceTimestampInPayload(payload: String, oldTs: TimeInterval, newTs: TimeInterval) -> String {

--- a/AEPAnalytics/Tests/FunctionalTests/AnalyticsAppExtConsequenceTests.swift
+++ b/AEPAnalytics/Tests/FunctionalTests/AnalyticsAppExtConsequenceTests.swift
@@ -49,7 +49,7 @@ class AnalyticsAppExtConsequenceTests: AnalyticsConsequenceTestBase {
         let expectedContextData = [
             "k1": "v1",
             "k2": "v2",
-            "a.action": "testActionName",
+            "a.action": "testActionName"
         ]
 
         XCTAssertEqual(mockNetworkService?.calledNetworkRequests.count, 1)

--- a/AEPAnalytics/Tests/FunctionalTests/AnalyticsConsequenceTests.swift
+++ b/AEPAnalytics/Tests/FunctionalTests/AnalyticsConsequenceTests.swift
@@ -51,7 +51,7 @@ class AnalyticsConsequenceTests: AnalyticsConsequenceTestBase {
         let expectedContextData = [
             "k1": "v1",
             "k2": "v2",
-            "a.action": "testActionName",
+            "a.action": "testActionName"
         ]
 
         XCTAssertEqual(mockNetworkService?.calledNetworkRequests.count, 1)

--- a/AEPAnalytics/Tests/FunctionalTests/AnalyticsFunctionalTestBase.swift
+++ b/AEPAnalytics/Tests/FunctionalTests/AnalyticsFunctionalTestBase.swift
@@ -176,7 +176,7 @@ class AnalyticsFunctionalTestBase: XCTestCase {
         let identitySharedState: [String: Any] = [
             AnalyticsTestConstants.Identity.EventDataKeys.VISITOR_ID_MID: "mid",
             AnalyticsTestConstants.Identity.EventDataKeys.VISITOR_ID_BLOB: "blob",
-            AnalyticsTestConstants.Identity.EventDataKeys.VISITOR_ID_LOCATION_HINT: "lochint",
+            AnalyticsTestConstants.Identity.EventDataKeys.VISITOR_ID_LOCATION_HINT: "lochint"
         ]
         simulateIdentityState(data: identitySharedState)
 

--- a/AEPAnalytics/Tests/FunctionalTests/AnalyticsHitReorderTestBase.swift
+++ b/AEPAnalytics/Tests/FunctionalTests/AnalyticsHitReorderTestBase.swift
@@ -110,7 +110,7 @@ class AnalyticsHitReorderTestBase: AnalyticsFunctionalTestBase {
         let trackData: [String: Any] = [
             CoreConstants.Keys.ACTION: "start",
             CoreConstants.Keys.CONTEXT_DATA: [
-                "k1": "v1",
+                "k1": "v1"
             ]
         ]
         let trackEvent = Event(name: "Generic track event", type: EventType.genericTrack, source: EventSource.requestContent, data: trackData)

--- a/AEPAnalytics/Tests/FunctionalTests/AnalyticsHitReorderTestBase.swift
+++ b/AEPAnalytics/Tests/FunctionalTests/AnalyticsHitReorderTestBase.swift
@@ -213,7 +213,7 @@ class AnalyticsHitReorderTestBase: AnalyticsFunctionalTestBase {
             "a.internalaction": "AdobeLink",
             "a.deeplink.id": "test_deeplinkId",
             "test_key_0": "test_value_0",
-            "test_key_1": "test_value_1",
+            "test_key_1": "test_value_1"
         ]
 
         verifyHit(request: mockNetworkService?.calledNetworkRequests[1],
@@ -232,7 +232,7 @@ class AnalyticsHitReorderTestBase: AnalyticsFunctionalTestBase {
         let trackData: [String: Any] = [
             CoreConstants.Keys.ACTION: "start",
             CoreConstants.Keys.CONTEXT_DATA: [
-                "k1": "v1",
+                "k1": "v1"
             ]
         ]
         let trackEvent = Event(name: "Generic track event", type: EventType.genericTrack, source: EventSource.requestContent, data: trackData)
@@ -294,7 +294,7 @@ class AnalyticsHitReorderTestBase: AnalyticsFunctionalTestBase {
         }
         let firstHitContextData = [
             "k1": "v1",
-            "a.action": "start",
+            "a.action": "start"
         ]
         verifyHit(request: mockNetworkService?.calledNetworkRequests[0],
                   host: "https://test.com/b/ss/rsid/0/",
@@ -331,7 +331,7 @@ class AnalyticsHitReorderTestBase: AnalyticsFunctionalTestBase {
             "a.internalaction": "Lifecycle",
             "a.deeplink.id": "test_deeplinkId",
             "test_key_0": "test_value_0",
-            "test_key_1": "test_value_1",
+            "test_key_1": "test_value_1"
         ]
         verifyHit(request: mockNetworkService?.calledNetworkRequests[1],
                   host: "https://test.com/b/ss/rsid/0/",
@@ -379,7 +379,7 @@ class AnalyticsHitReorderTestBase: AnalyticsFunctionalTestBase {
         let trackData: [String: Any] = [
             CoreConstants.Keys.ACTION: "start",
             CoreConstants.Keys.CONTEXT_DATA: [
-                "k1": "v1",
+                "k1": "v1"
             ]
         ]
         let trackEvent = Event(name: "Generic track event", type: EventType.genericTrack, source: EventSource.requestContent, data: trackData)

--- a/AEPAnalytics/Tests/FunctionalTests/AnalyticsIDTestBase.swift
+++ b/AEPAnalytics/Tests/FunctionalTests/AnalyticsIDTestBase.swift
@@ -45,7 +45,7 @@ class AnalyticsIDTestBase: AnalyticsFunctionalTestBase {
                 "mid": "mid",
                 "aamb": "blob",
                 "aamlh": "lochint",
-                "ts": String(trackEvent.timestamp.getUnixTimeInSeconds()),
+                "ts": String(trackEvent.timestamp.getUnixTimeInSeconds())
             ]
         } else {
             expectedVars = [
@@ -55,7 +55,7 @@ class AnalyticsIDTestBase: AnalyticsFunctionalTestBase {
                 "mid": "mid",
                 "aamb": "blob",
                 "aamlh": "lochint",
-                "ts": String(trackEvent.timestamp.getUnixTimeInSeconds()),
+                "ts": String(trackEvent.timestamp.getUnixTimeInSeconds())
             ]
         }
         let expectedContextData = [
@@ -108,7 +108,7 @@ class AnalyticsIDTestBase: AnalyticsFunctionalTestBase {
                 "vid": "testvid",
                 "aamb": "blob",
                 "aamlh": "lochint",
-                "ts": String(trackEvent.timestamp.getUnixTimeInSeconds()),
+                "ts": String(trackEvent.timestamp.getUnixTimeInSeconds())
             ]
         } else {
             expectedVars = [
@@ -120,7 +120,7 @@ class AnalyticsIDTestBase: AnalyticsFunctionalTestBase {
                 "vid": "testvid",
                 "aamb": "blob",
                 "aamlh": "lochint",
-                "ts": String(trackEvent.timestamp.getUnixTimeInSeconds()),
+                "ts": String(trackEvent.timestamp.getUnixTimeInSeconds())
             ]
         }
         let expectedContextData = [
@@ -211,7 +211,7 @@ class AnalyticsIDTestBase: AnalyticsFunctionalTestBase {
         let lifecycleSharedState: [String: Any] = [
             AnalyticsTestConstants.Lifecycle.EventDataKeys.LIFECYCLE_CONTEXT_DATA: [
                 AnalyticsTestConstants.Lifecycle.EventDataKeys.OPERATING_SYSTEM: "mockOSName",
-                AnalyticsTestConstants.Lifecycle.EventDataKeys.APP_ID: "mockAppName",
+                AnalyticsTestConstants.Lifecycle.EventDataKeys.APP_ID: "mockAppName"
             ]
         ]
 

--- a/AEPAnalytics/Tests/FunctionalTests/AnalyticsTrack+LifecycleTestBase.swift
+++ b/AEPAnalytics/Tests/FunctionalTests/AnalyticsTrack+LifecycleTestBase.swift
@@ -302,7 +302,6 @@ class AnalyticsTrack_LifecycleTestBase: AnalyticsFunctionalTestBase {
             "a.RunMode": "Application",
             "a.PrevSessionLength": "100"
         ]
-
         verifyHit(request: mockNetworkService?.calledNetworkRequests[0],
                   host: "https://test.com/b/ss/rsid/0/",
                   vars: sessionInfoVars,

--- a/AEPAnalytics/Tests/FunctionalTests/AnalyticsTrackTestBase.swift
+++ b/AEPAnalytics/Tests/FunctionalTests/AnalyticsTrackTestBase.swift
@@ -55,7 +55,7 @@ class AnalyticsTrackTestBase: AnalyticsFunctionalTestBase {
 
         let expectedContextData = [
             "k1": "v1",
-            "k2": "v2",
+            "k2": "v2"
         ]
 
         XCTAssertEqual(mockNetworkService?.calledNetworkRequests.count, 1)
@@ -68,7 +68,7 @@ class AnalyticsTrackTestBase: AnalyticsFunctionalTestBase {
      func trackStateEmptyTester() {
         let lifecycleSharedState: [String: Any] = [
             AnalyticsTestConstants.Lifecycle.EventDataKeys.LIFECYCLE_CONTEXT_DATA: [
-                AnalyticsTestConstants.Lifecycle.EventDataKeys.APP_ID: "mockAppName",
+                AnalyticsTestConstants.Lifecycle.EventDataKeys.APP_ID: "mockAppName"
             ]
         ]
 
@@ -159,7 +159,7 @@ class AnalyticsTrackTestBase: AnalyticsFunctionalTestBase {
         let expectedContextData = [
             "k1": "v1",
             "k2": "v2",
-            "a.action": "testAction",
+            "a.action": "testAction"
         ]
 
         XCTAssertEqual(mockNetworkService?.calledNetworkRequests.count, 1)
@@ -173,7 +173,7 @@ class AnalyticsTrackTestBase: AnalyticsFunctionalTestBase {
 
         let lifecycleSharedState: [String: Any] = [
             AnalyticsTestConstants.Lifecycle.EventDataKeys.LIFECYCLE_CONTEXT_DATA: [
-                AnalyticsTestConstants.Lifecycle.EventDataKeys.APP_ID: "mockAppName",
+                AnalyticsTestConstants.Lifecycle.EventDataKeys.APP_ID: "mockAppName"
             ]
         ]
 
@@ -266,7 +266,7 @@ class AnalyticsTrackTestBase: AnalyticsFunctionalTestBase {
         let expectedContextData = [
             "k1": "v1",
             "k2": "v2",
-            "a.internalaction": "testAction",
+            "a.internalaction": "testAction"
         ]
 
         XCTAssertEqual(mockNetworkService?.calledNetworkRequests.count, 1)
@@ -309,7 +309,7 @@ class AnalyticsTrackTestBase: AnalyticsFunctionalTestBase {
 
         let expectedContextData = [
             "k1": "v1",
-            "k2": "v2",
+            "k2": "v2"
         ]
 
         XCTAssertEqual(mockNetworkService?.calledNetworkRequests.count, 1)
@@ -333,7 +333,7 @@ class AnalyticsTrackTestBase: AnalyticsFunctionalTestBase {
                 "k2": "v2",
                 "a.AppID": "overwrittenApp",
                 "a.DeviceName": "overwrittenDevice",
-                "a.OSVersion": "overwrittenOS",
+                "a.OSVersion": "overwrittenOS"
             ]
         ]
 
@@ -418,7 +418,7 @@ class AnalyticsTrackTestBase: AnalyticsFunctionalTestBase {
         let expectedContextData = [
             "k1": "v1",
             "k2": "v2",
-            "a.action": "testAction",
+            "a.action": "testAction"
         ]
 
         XCTAssertEqual(mockNetworkService?.calledNetworkRequests.count, 1)

--- a/AEPAnalytics/Tests/UnitTests/AnalyticsHitProcessorTests.swift
+++ b/AEPAnalytics/Tests/UnitTests/AnalyticsHitProcessorTests.swift
@@ -58,7 +58,7 @@ class AnalyticsHitProcessorTests: XCTestCase {
 
     func testProcessHit_NetworkFailureRecoverableError() {
         // setup
-        let expectation = XCTestExpectation(description: "Callback should be invoked with true signaling this hit should not be retried")
+        let expectation = XCTestExpectation(description: "Callback should be invoked with false signaling this hit should be retried")
         let expectedUrl = URL.getAnalyticsBaseUrl(state: analyticsState)
         mockNetworkService?.expectedResponse = HttpConnection(data: nil, response: HTTPURLResponse(url: expectedUrl!, statusCode: 408, httpVersion: nil, headerFields: nil), error: nil)
 
@@ -69,6 +69,50 @@ class AnalyticsHitProcessorTests: XCTestCase {
         // test
         hitProcessor.processHit(entity: entity) { success in
             XCTAssertFalse(success)
+            expectation.fulfill()
+        }
+
+        // verify
+        wait(for: [expectation], timeout: 0.5)
+
+        XCTAssertTrue(mockNetworkService?.connectAsyncCalled ?? false) // network request should have been made
+    }
+
+    func testProcessHit_recoverableURLError() {
+        // setup
+        let expectation = XCTestExpectation(description: "Callback should be invoked with false signaling this hit should be retried")
+        let expectedUrl = URL.getAnalyticsBaseUrl(state: analyticsState)
+        mockNetworkService?.expectedResponse = HttpConnection(data: nil, response: nil, error: URLError(URLError.notConnectedToInternet))
+
+        let hit = AnalyticsHit(payload: "payload", timestamp: Date().timeIntervalSince1970, eventIdentifier: UUID().uuidString)
+
+        let entity = DataEntity(uniqueIdentifier: "test-uuid", timestamp: Date(), data: try! JSONEncoder().encode(hit))
+
+        // test
+        hitProcessor.processHit(entity: entity) { success in
+            XCTAssertFalse(success)
+            expectation.fulfill()
+        }
+
+        // verify
+        wait(for: [expectation], timeout: 0.5)
+
+        XCTAssertTrue(mockNetworkService?.connectAsyncCalled ?? false) // network request should have been made
+    }
+
+    func testProcessHit_unrecoverableURLError() {
+        // setup
+        let expectation = XCTestExpectation(description: "Callback should be invoked with true signaling this hit should not be retried")
+        let expectedUrl = URL.getAnalyticsBaseUrl(state: analyticsState)
+        mockNetworkService?.expectedResponse = HttpConnection(data: nil, response: nil, error: URLError(URLError.cannotFindHost))
+
+        let hit = AnalyticsHit(payload: "payload", timestamp: Date().timeIntervalSince1970, eventIdentifier: UUID().uuidString)
+
+        let entity = DataEntity(uniqueIdentifier: "test-uuid", timestamp: Date(), data: try! JSONEncoder().encode(hit))
+
+        // test
+        hitProcessor.processHit(entity: entity) { success in
+            XCTAssertTrue(success)
             expectation.fulfill()
         }
 

--- a/AEPAnalytics/Tests/UnitTests/AnalyticsHitProcessorTests.swift
+++ b/AEPAnalytics/Tests/UnitTests/AnalyticsHitProcessorTests.swift
@@ -81,7 +81,7 @@ class AnalyticsHitProcessorTests: XCTestCase {
     func testProcessHit_recoverableURLError() {
         // setup
         let expectation = XCTestExpectation(description: "Callback should be invoked with false signaling this hit should be retried")
-        let expectedUrl = URL.getAnalyticsBaseUrl(state: analyticsState)
+
         mockNetworkService?.expectedResponse = HttpConnection(data: nil, response: nil, error: URLError(URLError.notConnectedToInternet))
 
         let hit = AnalyticsHit(payload: "payload", timestamp: Date().timeIntervalSince1970, eventIdentifier: UUID().uuidString)
@@ -103,7 +103,7 @@ class AnalyticsHitProcessorTests: XCTestCase {
     func testProcessHit_unrecoverableURLError() {
         // setup
         let expectation = XCTestExpectation(description: "Callback should be invoked with true signaling this hit should not be retried")
-        let expectedUrl = URL.getAnalyticsBaseUrl(state: analyticsState)
+
         mockNetworkService?.expectedResponse = HttpConnection(data: nil, response: nil, error: URLError(URLError.cannotFindHost))
 
         let hit = AnalyticsHit(payload: "payload", timestamp: Date().timeIntervalSince1970, eventIdentifier: UUID().uuidString)

--- a/Package.swift
+++ b/Package.swift
@@ -20,11 +20,14 @@ let package = Package(
         .library(name: "AEPAnalytics", targets: ["AEPAnalytics"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/adobe/aepsdk-core-ios.git", .upToNextMajor(from: "5.0.0"))
+        .package(url: "https://github.com/adobe/aepsdk-core-ios.git", .upToNextMajor(from: "5.1.0"))
     ],
     targets: [
         .target(name: "AEPAnalytics",
-                dependencies: [.product(name: "AEPCore", package: "aepsdk-core-ios")],
+                dependencies: [
+                    .product(name: "AEPCore", package: "aepsdk-core-ios"),
+                    .product(name: "AEPServices", package: "aepsdk-core-ios"),
+                ],
                 path: "AEPAnalytics/Sources")
     ]
 )

--- a/Podfile
+++ b/Podfile
@@ -6,15 +6,15 @@ project 'AEPAnalytics.xcodeproj'
 
 pod 'SwiftLint', '0.52.0'
 
+
 def core_pods
-  pod 'AEPServices'
   pod 'AEPCore'
+  # TODO use production version of AEPServices after release
+  pod 'AEPServices', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v5.1.0'
   pod 'AEPRulesEngine'
 end
 
 def test_pods
-  pod 'AEPServices'
-  pod 'AEPCore'
   pod 'AEPLifecycle'
   pod 'AEPIdentity'
 end
@@ -33,15 +33,18 @@ end
 
 target 'TestAppiOS' do
   test_pods
+  core_pods
   pod 'AEPAssurance'
 end
 
 target 'TestAppExt' do
   test_pods
+  core_pods
 end
 
 target 'TestApptvOS' do
   test_pods
+  core_pods
 end
 
 post_install do |pi|

--- a/Podfile
+++ b/Podfile
@@ -9,8 +9,7 @@ pod 'SwiftLint', '0.52.0'
 
 def core_pods
   pod 'AEPCore'
-  # TODO use production version of AEPServices after release
-  pod 'AEPServices', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v5.1.0'
+  pod 'AEPServices'
   pod 'AEPRulesEngine'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -19,7 +19,7 @@ DEPENDENCIES:
   - AEPIdentity
   - AEPLifecycle
   - AEPRulesEngine
-  - AEPServices
+  - AEPServices (from `https://github.com/adobe/aepsdk-core-ios.git`, branch `dev-v5.1.0`)
   - SwiftLint (= 0.52.0)
 
 SPEC REPOS:
@@ -29,8 +29,17 @@ SPEC REPOS:
     - AEPIdentity
     - AEPLifecycle
     - AEPRulesEngine
-    - AEPServices
     - SwiftLint
+
+EXTERNAL SOURCES:
+  AEPServices:
+    :branch: dev-v5.1.0
+    :git: https://github.com/adobe/aepsdk-core-ios.git
+
+CHECKOUT OPTIONS:
+  AEPServices:
+    :commit: 2097e4f22ee2a058ee77dc11970902c0981a43aa
+    :git: https://github.com/adobe/aepsdk-core-ios.git
 
 SPEC CHECKSUMS:
   AEPAssurance: 7f260ded4df38a70a06efebade8c33a3e3221984
@@ -41,6 +50,6 @@ SPEC CHECKSUMS:
   AEPServices: e42e5118128e81c0f797fdfb1dc9c4a714d644b8
   SwiftLint: 13280e21cdda6786ad908dc6e416afe5acd1fcb7
 
-PODFILE CHECKSUM: 0ef2371de087379ab74555b35f66bbdc21992edf
+PODFILE CHECKSUM: 26cdd3b66ad79b58957b144cd4ec948153631bf3
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.13.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -10,7 +10,7 @@ PODS:
   - AEPLifecycle (5.0.0):
     - AEPCore (< 6.0.0, >= 5.0.0)
   - AEPRulesEngine (5.0.0)
-  - AEPServices (5.0.0)
+  - AEPServices (5.1.0)
   - SwiftLint (0.52.0)
 
 DEPENDENCIES:
@@ -19,7 +19,7 @@ DEPENDENCIES:
   - AEPIdentity
   - AEPLifecycle
   - AEPRulesEngine
-  - AEPServices (from `https://github.com/adobe/aepsdk-core-ios.git`, branch `dev-v5.1.0`)
+  - AEPServices
   - SwiftLint (= 0.52.0)
 
 SPEC REPOS:
@@ -29,17 +29,8 @@ SPEC REPOS:
     - AEPIdentity
     - AEPLifecycle
     - AEPRulesEngine
+    - AEPServices
     - SwiftLint
-
-EXTERNAL SOURCES:
-  AEPServices:
-    :branch: dev-v5.1.0
-    :git: https://github.com/adobe/aepsdk-core-ios.git
-
-CHECKOUT OPTIONS:
-  AEPServices:
-    :commit: 53a2af15cf53dac950ff072bff7f0acd3b7012a4
-    :git: https://github.com/adobe/aepsdk-core-ios.git
 
 SPEC CHECKSUMS:
   AEPAssurance: 7f260ded4df38a70a06efebade8c33a3e3221984
@@ -47,9 +38,9 @@ SPEC CHECKSUMS:
   AEPIdentity: a65c1eba43a06f01b0dab191b27a53a81adada57
   AEPLifecycle: d4e0e1e86d6225d87203875d67f56c48f7ab7f67
   AEPRulesEngine: fe5800653a4bee07b1e41e61b4d5551f0dba557b
-  AEPServices: e42e5118128e81c0f797fdfb1dc9c4a714d644b8
+  AEPServices: c38b809c32336f10f773525e65c71a949abe54a7
   SwiftLint: 13280e21cdda6786ad908dc6e416afe5acd1fcb7
 
-PODFILE CHECKSUM: 26cdd3b66ad79b58957b144cd4ec948153631bf3
+PODFILE CHECKSUM: 330fd00188309a38fbdc07d0f67a2af046cb1c07
 
 COCOAPODS: 1.13.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -38,7 +38,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   AEPServices:
-    :commit: 2097e4f22ee2a058ee77dc11970902c0981a43aa
+    :commit: 53a2af15cf53dac950ff072bff7f0acd3b7012a4
     :git: https://github.com/adobe/aepsdk-core-ios.git
 
 SPEC CHECKSUMS:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
![Screenshot 2024-05-15 at 1 18 33 PM](https://github.com/adobe/aepsdk-edge-ios/assets/4697559/1db5c91e-3610-46cc-b919-3ba546ab9a32)

- Added logic to retry hits failed with a recoverable URLError, which were previously discarded.
- Added tests.
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
